### PR TITLE
fix: fix broken ansible output of the hur module

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Publish to Ansible Galaxy
       env:
         COLLECTION_NAME: "hitachivantara.raidcom"
-        VERSION: "0.6.1"
+        VERSION: "0.6.3"
         API_KEY: ${{ secrets.ANSIBLE_COLLECTIONS_TOKEN }}
       run: |
         # Attempt to delete the existing collection (if supported)

--- a/changelogs/changelog.yml
+++ b/changelogs/changelog.yml
@@ -1,5 +1,15 @@
 ancestor: null
 releases:
+  0.6.3:
+    changes:
+      bugfixes:
+      - hur - fix module output which can't be deserialized leading to ansible failure
+      release_summary: Fix broken hur ansible module output
+    release_date: '2026-05-20'
+    modules:
+    - description: manage HUR (Hitachi Universal Replicator)
+      name: hur
+      namespace: 'hitachivantara.raidcom'
   0.6.2:
     changes:
       bugfixes:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: hitachivantara
 name: raidcom
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.6.2
+version: 0.6.3
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/modules/hur.py
+++ b/plugins/modules/hur.py
@@ -46,7 +46,7 @@ options:
     - The specific copy_group name as defined in the horcm file
     type: str
     required: true
-  
+
 requirements:
 - CCI/raidcom CLI software from support.hitachivantara.com (customer login required)
 - horcm.conf file, horcmstart and login done (work is in progress to automate this)
@@ -96,12 +96,13 @@ message:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.hitachivantara.raidcom.plugins.module_utils.hitachi_raidcom import hitachi_raidcom, hitachi_raidcom_argument_spec
-
+import io
+import sys
 
 def run_module():
 
-    # # define available arguments/parameters a user can pass to the module
-    # # add here the module specific values provided by the playbook
+    # define available arguments/parameters a user can pass to the module
+    # add here the module specific values provided by the playbook
     argument_spec = {
         "state": {"required": True, "type": "str", "choices": ["absent", "present", "resynced", "splitted", "takeover", "display", "query", "chkdsp"]},
         "copy_group": {"required": True, "type": "str"},
@@ -135,57 +136,70 @@ def run_module():
         supports_check_mode=True,
     )
 
-    raidcom = hitachi_raidcom(module)
+    # Use a capture buffer as a replacement for system stdout to keep proper behavior of dependencies
+    # without exposing their output to ansible
+    # Then swap the capture buffer again with real stdout to print the json result of the ansible module
+    capture_buffer = io.StringIO()
+    real_stdout = sys.stdout
+    try:
+        sys.stdout = capture_buffer
+        raidcom = hitachi_raidcom(module)
 
-    # if the user is working with this module in only check mode we do not
-    # make any changes to the environment
-    # for now just acknowledge we run in check mode and are aware of
-    result['facts'] = {}  # result['facts'] = dict() pylint complains
-    # Check mode should not print anything. A warning would help me to understand better if checkmode was active.
-    # if module.check_mode:
-    #    module.warn('*** Check Mode Active *** No changes will be executed !')
+        # if the user is working with this module in only check mode we do not
+        # make any changes to the environment
+        # for now just acknowledge we run in check mode and are aware of
+        result['facts'] = {}  # result['facts'] = dict() pylint complains
+        # Check mode should not print anything. A warning would help me to understand better if checkmode was active.
+        # if module.check_mode:
+        #    module.warn('*** Check Mode Active *** No changes will be executed !')
 
-    # query/display: get current hur pair status information
-    if (module.params["state"] == "query") or (module.params["state"] == "display"):
-        result['facts'] = raidcom.hur_status()
-        result['changed'] = False
+        # query/display: get current hur pair status information
+        if (module.params["state"] == "query") or (module.params["state"] == "display"):
+            result['facts'] = raidcom.hur_status()
+            result['changed'] = False
 
-    # present: pair create
-    if module.params["state"] == "present":
-        result['facts'] = raidcom.hur_create()
-        result['changed'] = True
+        # present: pair create
+        if module.params["state"] == "present":
+            result['facts'] = raidcom.hur_create()
+            result['changed'] = True
 
-    # absent: pair delete (simplex)
-    if module.params["state"] == "absent":
-        result['facts'] = raidcom.hur_delete()
-        result['changed'] = True
+        # absent: pair delete (simplex)
+        if module.params["state"] == "absent":
+            result['facts'] = raidcom.hur_delete()
+            result['changed'] = True
 
-    # absent: pair splitted (psus/ssus)
-    if module.params["state"] == "splitted":
-        result['facts'] = raidcom.hur_split()
-        result['changed'] = True
+        # absent: pair splitted (psus/ssus)
+        if module.params["state"] == "splitted":
+            result['facts'] = raidcom.hur_split()
+            result['changed'] = True
 
-    # absent: pair resync
-    if module.params["state"] == "resynced":
-        result['facts'] = raidcom.hur_resync()
-        result['changed'] = True
+        # absent: pair resync
+        if module.params["state"] == "resynced":
+            result['facts'] = raidcom.hur_resync()
+            result['changed'] = True
 
-    # absent: pair horctakeover
-    if module.params["state"] == "takeover":
-        result['facts'] = raidcom.hur_takeover()
-        result['changed'] = True
-        
-    # absent: pair raidvchkdsp
-    if module.params["state"] == "chkdsp":
-        result['facts'] = raidcom.hur_chkdsp()
-        result['changed'] = False
+        # absent: pair horctakeover
+        if module.params["state"] == "takeover":
+            result['facts'] = raidcom.hur_takeover()
+            result['changed'] = True
 
-    # query/display: get current hur pair status information
-    #if module.params["state"] == "splitted":
-    #    result['facts'] = raidcom.hur_split()
-    #    #result['changed'] = False
+        # absent: pair raidvchkdsp
+        if module.params["state"] == "chkdsp":
+            result['facts'] = raidcom.hur_chkdsp()
+            result['changed'] = False
 
-    module.exit_json(**result)
+        # query/display: get current hur pair status information
+        #if module.params["state"] == "splitted":
+        #    result['facts'] = raidcom.hur_split()
+        #    #result['changed'] = False
+    except Exception as e:
+        sys.stdout = real_stdout
+        module.fail_json(msg=f"Raidcom error: {e}")
+    else:
+        sys.stdout = real_stdout
+        module.exit_json(**result)
+    finally:
+        sys.stdout = real_stdout
 
 # Main
 def main():


### PR DESCRIPTION
Hi @gchiapparini,

Your latest update properly fixes the import issues with the hur module, but starting from ansible >=2.19, it looks like dependencies from the hur module are printing in the standard output when the module runs, which messes up the json output, which can't be deserialized by ansible and make playbooks fail: 

```
[ERROR]: Task failed: Action failed: Module result deserialization failed: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```

This PR fixes the problem by letting these dependencies print their stuff in an intermediate buffer that will "absorb" this unexpected output, allowing the actual module code to cleanly print it's json output in the end which makes it serializable as expected.

I tested the code and compared the output that I get from this module using ansible 2.18 which works normally using `0.6.2`, and then tested this version with ansible 2.20 and can confirm I'm getting the exact same output from the module which confirms that it works as expected.

Could you check and merge this ?

Thanks