### PR TITLE
fix(galaxy): correct repository URL typo and release 0.6.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Publish to Ansible Galaxy
       env:
         COLLECTION_NAME: "hitachivantara.raidcom"
-        VERSION: "0.6.3"
+        VERSION: "0.6.4"
         API_KEY: ${{ secrets.ANSIBLE_COLLECTIONS_TOKEN }}
       run: |
         # Attempt to delete the existing collection (if supported)

--- a/changelogs/changelog.yml
+++ b/changelogs/changelog.yml
@@ -1,5 +1,12 @@
 ancestor: null
 releases:
+  0.6.4:
+    changes:
+      bugfixes:
+      - galaxy.yml - fix typo in repository URL (``hhitachi-vantara`` -> ``hitachi-vantara``)
+        so the "View on GitHub" link on Ansible Galaxy resolves correctly
+      release_summary: Fix repository URL typo in collection metadata
+    release_date: '2026-06-04'
   0.6.3:
     changes:
       bugfixes:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: hitachivantara
 name: raidcom
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.6.3
+version: 0.6.4
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -44,7 +44,7 @@ tags: [hitachi,vantara,storage,vsp,raidcom,cci,horcm,hiraid]
 dependencies: {}
 
 # The URL of the originating SCM repository
-repository: https://github.com/hhitachi-vantara/hitachi.raidcom.ansible
+repository: https://github.com/hitachi-vantara/hitachi.raidcom.ansible
 
 # The URL to any online docs
 documentation: https://github.com/hitachi-vantara/hitachi.raidcom.ansible


### PR DESCRIPTION
## Summary

- Fixes a typo in `galaxy.yml`'s `repository:` field: `hhitachi-vantara` (extra `h`) → `hitachi-vantara`. The bad URL was being surfaced by Ansible Galaxy and caused the "View on GitHub" link to 404.
- Bumps `galaxy.yml` and `.github/workflows/publish.yml` to `0.6.4`.
- Adds a `0.6.4` changelog entry.

## Test plan

- [ ] After merge, confirm GHA `Publish Ansible Collection` workflow succeeds on `main`.
- [ ] On https://galaxy.ansible.com/hitachivantara/raidcom verify version `0.6.4` is listed and the repository link resolves to `https://github.com/hitachi-vantara/hitachi.raidcom.ansible`.